### PR TITLE
add missing dependencies and a helper class to run the examples...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSC
 
 // additional libraries
 libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-sql" % "2.2.0",
+  "org.apache.spark" %% "spark-hive" % "2.2.0",
   "org.scalatest" %% "scalatest" % "3.0.1",
   "org.scalacheck" %% "scalacheck" % "1.13.4",
   "junit" % "junit" % "4.12",

--- a/src/main/scala/com/high-performance-spark-examples/dataframe/PandaExerciser.scala
+++ b/src/main/scala/com/high-performance-spark-examples/dataframe/PandaExerciser.scala
@@ -1,0 +1,23 @@
+package com.highperformancespark.examples.dataframe
+
+import com.highperformancespark.examples.dataframe.RawPanda
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Dataset, Row, SQLContext}
+
+
+
+object PandaExerciser extends App {
+  
+  val sc = new SparkContext("local[2]", "Panda-o-rama")
+  val sqlContext=new SQLContext(sc);
+
+  val session=sqlContext.sparkSession
+
+  val p1 = RawPanda(1, "M1B 5K7", "giant", true, Array(0.1, 0.1))
+  val p2 = RawPanda(1, "M1B 6K7", "giant", false, Array(0.1, 0.1))
+
+  val pandaInfo= session.createDataFrame(Seq(p1, p2))
+  val result: Dataset[Row] = pandaInfo.filter(pandaInfo("happy") !== true)
+  println("result:" + result);
+  result.show()
+}


### PR DESCRIPTION
Thanks for the very useful book. I am on chapter 3 and I tried to run the first 
Panda filtering example, but could not due to some dependencies that 
seem to be missing from build.sbt

You might want to consider making the examples more copy-pasteable, or alternatively,
runnable out of the box from the github code referenced by the book  (apologies if 
there is a way to do this that I happened to miss.)

Anyway, this PR implements one approach to accomplish the above:

After I added the missing dependencies and the above runner class I was able to start the 
filter example by right clicking on 
    com.highperformancespark.examples.dataframe.PandaExerciser
(in my IDE, Intellij IDEA) then selecting 'Run'.

